### PR TITLE
Update to esp-hal 1.0.0 - migration step

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,7 @@ runner = "espflash flash --monitor"
 
 [env]
 ESP_LOG="INFO"
+ESP_HAL_CONFIG_PSRAM_MODE = "octal"
 
 [build]
 rustflags = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,19 +7,20 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-esp-hal = "0.22.0"
-esp-backtrace = { version = "0.14.2", features = [
+esp-hal = "0.23.1"
+esp-backtrace = { version = "0.15.0", features = [
     "panic-handler",
     "println"
 ] }
-esp-println = { version = "0.12.0", features = [ "log" ] }
+esp-println = { version = "0.13.0", features = [ "log" ] }
 log = { version = "0.4.21" }
 
-esp-alloc = "0.5.0"
+esp-alloc = "0.6.0"
 embedded-graphics = "0.8.0"
 embedded-hal = "1.0.0"
-mipidsi = "0.8.0"
-esp-display-interface-spi-dma = "0.2.0"
+mipidsi = "0.9.0"
+#esp-display-interface-spi-dma = "0.3.0"
+esp-display-interface-spi-dma = { path = "../esp-display-interface-spi-dma"}
 esp-bsp = "0.4.1"
 embedded-graphics-framebuf = { version = "0.3.0", git = "https://github.com/georgik/embedded-graphics-framebuf.git", branch = "feature/embedded-graphics-0.8" }
 heapless = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,26 +7,27 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-esp-hal = "0.23.1"
-esp-backtrace = { version = "0.15.0", features = [
+esp-hal = { version = "1.0.0-beta.0", features = ["esp32s3", "unstable"] }
+esp-backtrace = { version = "0.15.1", features = [
     "panic-handler",
     "println"
 ] }
-esp-println = { version = "0.13.0", features = [ "log" ] }
-log = { version = "0.4.21" }
+esp-println = { version = "0.13", features = [ "log" ] }
+log = { version = "0.4.26" }
 
-esp-alloc = "0.6.0"
-embedded-graphics = "0.8.0"
+esp-alloc = "0.7.0"
+embedded-graphics = "0.8.1"
 embedded-hal = "1.0.0"
 mipidsi = "0.9.0"
 #esp-display-interface-spi-dma = "0.3.0"
-esp-display-interface-spi-dma = { path = "../esp-display-interface-spi-dma"}
+# esp-display-interface-spi-dma = { path = "../esp-display-interface-spi-dma"}
 esp-bsp = "0.4.1"
 embedded-graphics-framebuf = { version = "0.3.0", git = "https://github.com/georgik/embedded-graphics-framebuf.git", branch = "feature/embedded-graphics-0.8" }
 heapless = "0.8.0"
+embedded-hal-bus = "0.3.0"
 
 
 [features]
 default = [ "esp-hal/esp32s3", "esp-backtrace/esp32s3", "esp-println/esp32s3", "esp32-s3-box-3" ]
 
-esp32-s3-box-3 = [ "esp-bsp/esp32-s3-box-3", "esp-hal/octal-psram" ]
+esp32-s3-box-3 = [ "esp-bsp/esp32-s3-box-3", "esp-hal/psram" ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,11 +20,10 @@ use esp_hal::gpio::Pull;
 use esp_hal::rng::Rng;
 use esp_hal::{
     delay::Delay,
-    dma::Dma,
     dma::DmaPriority,
     gpio::{Level, Output},
-    prelude::*,
     spi::master::Spi,
+    main
 };
 
 use embedded_graphics_framebuf::FrameBuf;
@@ -156,7 +155,7 @@ fn draw_grid<D: DrawTarget<Color = Rgb565>>(
     Ok(())
 }
 
-#[entry]
+#[main]
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
     esp_println::logger::init_logger_from_env();


### PR DESCRIPTION
Update to esp-hal 1.0.0 and new mipidsi.

This MR disables DMA and BSP for time-being.